### PR TITLE
Fix Eve Reset Error Issue + Debugging Console

### DIFF
--- a/scenes/debug_console.gd
+++ b/scenes/debug_console.gd
@@ -1,0 +1,24 @@
+# INFO Source: https://www.youtube.com/watch?v=aaFDnnrTSGg
+
+extends Node2D
+
+@onready var line_edit: LineEdit = $LineEdit
+@onready var label: Label = $label
+
+# Called when the node enters the scene tree for the first time.
+func _ready() -> void:
+	line_edit.text_submitted.connect(_on_LineEdit_text_entered)
+
+
+# Called every frame. 'delta' is the elapsed time since the previous frame.
+func _process(delta: float) -> void:
+	pass
+
+func _on_LineEdit_text_entered(new_text):
+	#print(new_text)
+	
+	if new_text == "test_environment":
+		get_tree().change_scene_to_file("res://scenes/movement_cont.tscn")
+		
+	if new_text == "level_1":
+		get_tree().change_scene_to_file("res://scenes/level_1_scene.tscn")

--- a/scenes/debug_console.gd.uid
+++ b/scenes/debug_console.gd.uid
@@ -1,0 +1,1 @@
+uid://cigr5c8rvew4i

--- a/scenes/debug_console.tscn
+++ b/scenes/debug_console.tscn
@@ -1,0 +1,14 @@
+[gd_scene format=3 uid="uid://wgg2gorg83vj"]
+
+[ext_resource type="Script" uid="uid://cigr5c8rvew4i" path="res://scenes/debug_console.gd" id="1_hpx2j"]
+
+[node name="Debug Console" type="Node2D" unique_id=1129319356]
+script = ExtResource("1_hpx2j")
+
+[node name="LineEdit" type="LineEdit" parent="." unique_id=1177162787]
+offset_right = 333.0
+offset_bottom = 31.0
+
+[node name="Label" type="Label" parent="." unique_id=2079759181]
+offset_right = 40.0
+offset_bottom = 23.0

--- a/scenes/level_1_scene.tscn
+++ b/scenes/level_1_scene.tscn
@@ -7,6 +7,8 @@
 [ext_resource type="Script" uid="uid://8umksf8e80fw" path="res://addons/phantom_camera/scripts/resources/tween_resource.gd" id="3_d0nkq"]
 [ext_resource type="PackedScene" uid="uid://dnjf1aqiogr0k" path="res://scenes/level_1_floorplan.tscn" id="3_vdyla"]
 [ext_resource type="PackedScene" uid="uid://b7y82qoyrdjis" path="res://scenes/box.tscn" id="7_cowtf"]
+[ext_resource type="PackedScene" uid="uid://c27i3jdck2hje" path="res://scenes/movement_cont.tscn" id="8_1lfwu"]
+[ext_resource type="PackedScene" uid="uid://wgg2gorg83vj" path="res://scenes/debug_console.tscn" id="9_d18id"]
 
 [sub_resource type="Resource" id="Resource_d0nkq"]
 script = ExtResource("3_d0nkq")
@@ -129,3 +131,9 @@ position = Vector2(993, 6174)
 [node name="Box16" parent="." unique_id=822512834 instance=ExtResource("7_cowtf")]
 z_index = 10
 position = Vector2(1133, 6173)
+
+[node name="Test Environment" parent="." unique_id=1107117117 instance=ExtResource("8_1lfwu")]
+
+[node name="Debug Console" parent="." unique_id=1129319356 instance=ExtResource("9_d18id")]
+z_index = 10
+position = Vector2(-26, -124)

--- a/scenes/movement_cont.tscn
+++ b/scenes/movement_cont.tscn
@@ -3,6 +3,7 @@
 [ext_resource type="Texture2D" uid="uid://butu7b2wedoks" path="res://assets/tempSprites/freddy_fazbear_shocked.png" id="1_pibr7"]
 [ext_resource type="PackedScene" uid="uid://w6s64ylvwlya" path="res://scenes/player.tscn" id="2_qakxd"]
 [ext_resource type="PackedScene" uid="uid://cphkguivqa6gt" path="res://scenes/player2.tscn" id="3_464wy"]
+[ext_resource type="PackedScene" uid="uid://wgg2gorg83vj" path="res://scenes/debug_console.tscn" id="4_qakxd"]
 
 [sub_resource type="WorldBoundaryShape2D" id="WorldBoundaryShape2D_olwqp"]
 
@@ -45,3 +46,6 @@ shape = SubResource("WorldBoundaryShape2D_rcwxk")
 position = Vector2(1059, 292)
 rotation = -1.5707964
 shape = SubResource("WorldBoundaryShape2D_rww21")
+
+[node name="Debug Console" parent="." unique_id=1129319356 instance=ExtResource("4_qakxd")]
+position = Vector2(530, 55)

--- a/scripts/playermv.gd
+++ b/scripts/playermv.gd
@@ -1,7 +1,9 @@
 extends CharacterBody2D
 
 const SPEED = 300.0
-var lastDirection : String
+
+# INFO: Assuming that Eve starts out facing to the front
+var lastDirection : String = "S"
 
 const PUSH_FORCE = 150.0
 
@@ -53,8 +55,9 @@ func _physics_process(delta):
 		lastDirection = "S+D"
 	
 	# INFO meant to return animation to idle, but SHITS the debugger - Lizz
-	# elif velocity == Vector2.ZERO:
-	#	$AnimationPlayer.play("Eve_Idle_" + lastDirection)
+	# INFO I think this fixes it? But I don't know if this is what you had in mind - Nick
+	elif velocity == Vector2.ZERO:
+		$AnimationPlayer.play("Eve_Idle_" + lastDirection)
 	
 func check_box_collision(x_push, y_push, delta):
 	for i in get_slide_collision_count():


### PR DESCRIPTION
## Summary of Changes
- Tried to fix an issue where, when attempting to reset Eve's animation when she is not moving, Godot would display many errors
- Started implementation of a debugging console

## How to See the Changes
- Open the Godot Project
- In the scenes folder, there should be a `debug_console.tscn` scene file that houses the debugging console and its script
- Run the game in either `level_1_scene.tscn` (I think) or `movement_cont.tscn`
- In Godot, as we move Eve, there should not be as many errors being outputted relating to Eve's animation sprite?
- There should be a black and translucent rectangle, which is the debugging console
- Enter `test_environment` in the console and press enter to switch scenes to the test environment
- Enter `level_1` in the console and press enter to switch scenes to level 1

## Current Issues
- We do have some errors being outputted regarding the debugging console