### PR TITLE
Inventory Node Retrieval Revision

### DIFF
--- a/project.godot
+++ b/project.godot
@@ -11,7 +11,7 @@ config_version=5
 [application]
 
 config/name="NoInfoGame"
-run/main_scene="uid://cm7a4a4nop8y0"
+run/main_scene="uid://dy6vmnugwo4au"
 config/features=PackedStringArray("4.6", "Forward Plus")
 config/icon="uid://bxl245j7738ni"
 

--- a/scenes/collectibles.gd
+++ b/scenes/collectibles.gd
@@ -36,7 +36,42 @@ func body_exit(body):
 
 func pickup(player):
 	if item_info:
-		var inv = player.get_node("../UI/SharedInv/Inventory")
+		#var inv = player.get_node("../UI/SharedInv/Inventory")
+		var inv = find_inventory()
+		if inv == null:
+			print("inventory not found in collectibles.gd... returning early in pickup()")
+			return
+		
 		if inv:
 			inv.add_item(item_info)
 			queue_free()
+
+# Copied from playermv.gd and player2mv.gd
+func find_inventory():
+	var root = get_tree().root.get_child(0)
+	
+	var inventory = null
+	var current_node = get_node(".")
+	
+	# Not really required, but basically limit the while loop to run up to 1000 times
+	# Currently, I don't think our game is 1000 parent nodes deep (at the moment, it's around 5-10 usually?)
+	const MAX_ITERATIONS = 1000
+	var safetyIndex = 0
+	
+	while safetyIndex < MAX_ITERATIONS:
+		#print(current_node.name)
+		
+		if current_node == root:
+			break
+		
+		# get_node will either be null if the filepath at that moment doesn't exist...
+		# ...or not null if the filepath exists!
+		inventory = current_node.get_node("UI/SharedInv/Inventory")
+		if inventory != null:
+			break
+		
+		# Go to the parent node of the current node we are at
+		current_node = current_node.get_node("..")
+		safetyIndex += 1
+	
+	return inventory

--- a/scenes/level_1_scene.tscn
+++ b/scenes/level_1_scene.tscn
@@ -16,6 +16,7 @@
 [ext_resource type="Texture2D" uid="uid://dl2r3y450gx41" path="res://assets/sprites/environment/SleeplessChild_Bed-Complete.png" id="13_2ydo2"]
 [ext_resource type="PackedScene" uid="uid://bwd22jx5mssx0" path="res://scenes/black_light_flashlight_item.tscn" id="13_xb17u"]
 [ext_resource type="Texture2D" uid="uid://dkmocmuvlptk4" path="res://assets/tempSprites/key_placeholder.png" id="14_xb17u"]
+[ext_resource type="PackedScene" uid="uid://dwu4oi2tru041" path="res://scenes/collectibles.tscn" id="17_tqr37"]
 
 [sub_resource type="Resource" id="Resource_d0nkq"]
 script = ExtResource("3_d0nkq")
@@ -314,3 +315,7 @@ z_index = 5
 position = Vector2(783, 5194)
 scale = Vector2(0.14522077, 0.14522079)
 texture = ExtResource("14_xb17u")
+
+[node name="key" parent="." unique_id=1417814454 instance=ExtResource("17_tqr37")]
+z_index = 8
+position = Vector2(333, -230)

--- a/scenes/player2mv.gd
+++ b/scenes/player2mv.gd
@@ -83,10 +83,13 @@ func check_box_collision(x_push, y_push, delta):
 			collision_box.push_by_player(Vector2(delta * x_push, delta * y_push), PUSH_FORCE)
 
 func check_to_open_door():
-	
-	var inventory = get_node("../UI/SharedInv/Inventory")
+	# Find the inventory first
+	var inventory = find_inventory()
 	if inventory == null:
 		print("danger type beat")
+		print("inventory not found")
+		return
+	
 	for i in get_slide_collision_count():
 		var collision = get_slide_collision(i)
 		var door = collision.get_collider()
@@ -106,3 +109,32 @@ func check_to_open_door():
 			
 			# Change the door collision so players can enter the door
 			door.get_node("Closed Door Collision").set_deferred("disabled", true)
+
+func find_inventory():
+	var root = get_tree().root.get_child(0)
+	
+	var inventory = null
+	var current_node = get_node(".")
+	
+	# Not really required, but basically limit the while loop to run up to 1000 times
+	# Currently, I don't think our game is 1000 parent nodes deep (at the moment, it's around 5-10 usually?)
+	const MAX_ITERATIONS = 1000
+	var safetyIndex = 0
+	
+	while safetyIndex < MAX_ITERATIONS:
+		#print(current_node.name)
+		
+		if current_node == root:
+			break
+		
+		# get_node will either be null if the filepath at that moment doesn't exist...
+		# ...or not null if the filepath exists!
+		inventory = current_node.get_node("UI/SharedInv/Inventory")
+		if inventory != null:
+			break
+		
+		# Go to the parent node of the current node we are at
+		current_node = current_node.get_node("..")
+		safetyIndex += 1
+	
+	return inventory

--- a/scripts/playermv.gd
+++ b/scripts/playermv.gd
@@ -86,10 +86,13 @@ func check_box_collision(x_push, y_push, delta):
 			collision_box.push_by_player(Vector2(delta * x_push, delta * y_push), PUSH_FORCE)
 
 func check_to_open_door():
-	
-	var inventory = get_node("../UI/SharedInv/Inventory")
+	# Find the inventory first
+	var inventory = find_inventory()
 	if inventory == null:
 		print("danger type beat")
+		print("inventory not found")
+		return
+	
 	for i in get_slide_collision_count():
 		var collision = get_slide_collision(i)
 		var door = collision.get_collider()
@@ -109,3 +112,32 @@ func check_to_open_door():
 			
 			# Change the door collision so players can enter the door
 			door.get_node("Closed Door Collision").set_deferred("disabled", true)
+
+func find_inventory():
+	var root = get_tree().root.get_child(0)
+	
+	var inventory = null
+	var current_node = get_node(".")
+	
+	# Not really required, but basically limit the while loop to run up to 1000 times
+	# Currently, I don't think our game is 1000 parent nodes deep (at the moment, it's around 5-10 usually?)
+	const MAX_ITERATIONS = 1000
+	var safetyIndex = 0
+	
+	while safetyIndex < MAX_ITERATIONS:
+		#print(current_node.name)
+		
+		if current_node == root:
+			break
+		
+		# get_node will either be null if the filepath at that moment doesn't exist...
+		# ...or not null if the filepath exists!
+		inventory = current_node.get_node("UI/SharedInv/Inventory")
+		if inventory != null:
+			break
+		
+		# Go to the parent node of the current node we are at
+		current_node = current_node.get_node("..")
+		safetyIndex += 1
+	
+	return inventory


### PR DESCRIPTION
## Summary of Changes
- Revised the `playermv.gd`, `player2mv.gd`, and `collectibles.gd` scripts to search through the scene tree more for the inventory node. Previously, I think we only had one specific filepath to get the inventory, so this change adds a while loop that tries to get the inventory node, and if it does not work, it will move to the parent directory and search for the inventory node, and repeat that until we either find the inventory node or reach the root node (or a node close to the root node at least).